### PR TITLE
fix : makefile error (cmd : start)

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ run:
 	make run_backend & make run_frontend
 
 start:
-	make runk
+	make run
 
 # Testing
 install_test:


### PR DESCRIPTION
## Describe Your Changes
### Issue with the Makefile
There was a typo in the Makefile under the start target, which incorrectly used ```make runk```. Since the ```runk``` target does not exist, I corrected this to ```make run```.

## Screenshots (if appropriate):
No :)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have written unit tests for my code if applicable
- [X] I have formatted my code according to the style guide (use `make format` & `make check`)
